### PR TITLE
Add search selection styles to color themes

### DIFF
--- a/colors/abyss.lua
+++ b/colors/abyss.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#101010" }
 style.scrollbar = { common.color "#252525" }
 style.scrollbar2 = { common.color "#444444" }
 
+style.search_selection = { common.color "#0633c6" }
+style.search_selection_text = { common.color "#ff9933" }
+
 style.syntax = {}
 style.syntax["normal"] = { common.color "#a0a0a0" }
 style.syntax["symbol"] = { common.color "#a0a0a0" }

--- a/colors/bearded-theme-vivid-black.lua
+++ b/colors/bearded-theme-vivid-black.lua
@@ -39,6 +39,9 @@ style.syntax["string"] = { common.color "#42DD76" } -- strings
 style.syntax["operator"] = { common.color "#c8c8c8" } -- operators
 style.syntax["function"] = { common.color "#FFB638" }  -- functions
 
+style.search_selection = { common.color "#5f5f6d" }
+style.search_selection_text = { common.color "#c8c8c8" }
+
 style.caret = { common.color "#FFB638" } -- caret
 
 style.line_highlight = { common.color "#aaaaaa0d" } -- editor line highlighting

--- a/colors/betelgeuse.lua
+++ b/colors/betelgeuse.lua
@@ -27,6 +27,9 @@ style.warn               = { common.color "#f5ad44" }
 style.error              = { common.color "#db504a" }
 style.modified           = { common.color "#448bf5" }
 
+style.search_selection = { common.color "#5f5f6d" }
+style.search_selection_text = { common.color "#c8c8c8" }
+
 -- Syntax --
 style.syntax             = {}
 style.syntax["normal"]   = { common.color "#dfe2e7" }

--- a/colors/c0mfy.lua
+++ b/colors/c0mfy.lua
@@ -16,10 +16,13 @@ style.line_highlight = { common.color "#2d303d" }
 style.scrollbar = { common.color "#44475a" }
 style.scrollbar2 = { common.color "#4c5163" }
 
+style.search_selection = { common.color "#0e218b" }
+style.search_selection_text = { common.color "#ff9933" }
+
 style.syntax = {}
 style.syntax["normal"] = { common.color "#f5faff" }
 style.syntax["symbol"] = { common.color "#f5faff" }
-style.syntax["comment"] = { common.color "#081355" }
+style.syntax["comment"] = { common.color "#0d208c" }
 style.syntax["keyword"] = { common.color "#fc0fc0" }
 style.syntax["keyword2"] = { common.color "#05e6fa" }
 style.syntax["number"] = { common.color "#7612c5" }

--- a/colors/catppuccin-frappe.lua
+++ b/colors/catppuccin-frappe.lua
@@ -17,6 +17,9 @@ style.scrollbar = { common.color "#626880" }
 style.scrollbar2 = { common.color "#737994" }
 style.scrollbar_track = { common.color "#292c3c" }
 
+style.search_selection = { common.color "#1f222e" }
+style.search_selection_text = { common.color "#efa9aa" }
+
 style.syntax["normal"] = { common.color "#e78284" }
 style.syntax["symbol"] = { common.color "#babbf1" }
 style.syntax["comment"] = { common.color "#737994" }

--- a/colors/catppuccin-latte.lua
+++ b/colors/catppuccin-latte.lua
@@ -17,6 +17,9 @@ style.scrollbar = { common.color "#acb0be" }
 style.scrollbar2 = { common.color "#9ca0b0" }
 style.scrollbar_track = { common.color "#dce0e8" } -- crust
 
+style.search_selection = { common.color "#4f5f7d" }
+style.search_selection_text = { common.color "#ff9900" }
+
 style.syntax["normal"] = { common.color "#d20f39" }
 style.syntax["symbol"] = { common.color "#7287fd" }
 style.syntax["comment"] = { common.color "#9ca0b0" }

--- a/colors/catppuccin-macchiato.lua
+++ b/colors/catppuccin-macchiato.lua
@@ -17,6 +17,9 @@ style.scrollbar = { common.color "#5b6078" }
 style.scrollbar2 = { common.color "#6e738d" }
 style.scrollbar_track = { common.color "#1e2030" }
 
+style.search_selection = { common.color "#4f567d" }
+style.search_selection_text = { common.color "#ff9900" }
+
 style.syntax["normal"] = { common.color "#ed8796" }
 style.syntax["symbol"] = { common.color "#b7bdf8" }
 style.syntax["comment"] = { common.color "#6e738d" }

--- a/colors/catppuccin-mocha.lua
+++ b/colors/catppuccin-mocha.lua
@@ -16,6 +16,9 @@ style.scrollbar = { common.color "#585b70" } -- surface2
 style.scrollbar2 = { common.color "#6c7086" } -- overlay0
 style.scrollbar_track = { common.color "#181825" } -- mantle
 
+style.search_selection = { common.color "#3c3c5d" }
+style.search_selection_text = { common.color "#ffad33" }
+
 style.syntax["normal"] = { common.color "#f38ba8" } -- red
 style.syntax["symbol"] = { common.color "#b4befe" } -- lavender
 style.syntax["comment"] = { common.color "#6c7086" } -- overlay0

--- a/colors/cold_lime.lua
+++ b/colors/cold_lime.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#415256" }
 style.scrollbar = { common.color "#6c71c4" }
 style.scrollbar2 = { common.color "#6c71c4" }
 
+style.search_selection = { common.color "#031317" }
+style.search_selection_text = { common.color "#f053f3" }
+
 style.syntax["normal"] = { common.color "#00d1d1" }
 style.syntax["symbol"] = { common.color "#00ff7f" }
 style.syntax["comment"] = { common.color "#6c71c4" }

--- a/colors/dracula.lua
+++ b/colors/dracula.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#313442" }
 style.scrollbar = { common.color "#44475a" }
 style.scrollbar2 = { common.color "#ff79c6" }
 
+style.search_selection = { common.color "#16171d" }
+style.search_selection_text = { common.color "#e1f50a" }
+
 style.syntax["normal"] = { common.color "#f8f8f2" }
 style.syntax["symbol"] = { common.color "#f8f8f2" }
 style.syntax["comment"] = { common.color "#6272a4" }

--- a/colors/duorand.lua
+++ b/colors/duorand.lua
@@ -25,6 +25,9 @@ style.line_highlight = { common.color "#101010" }
 style.scrollbar = { common.color "#252525" }
 style.scrollbar2 = { common.color "#444444" }
 
+style.search_selection = { common.color "#333333" }
+style.search_selection_text = { common.color "#dfdfdf" }
+
 style.syntax = {}
 style.syntax["normal"] = { common.color "#a0a0a0" }
 style.syntax["symbol"] = { common.color "#a0a0a0" }

--- a/colors/duotone.lua
+++ b/colors/duotone.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#101010" }
 style.scrollbar = { common.color "#252525" }
 style.scrollbar2 = { common.color "#444444" }
 
+style.search_selection = { common.color "#333333" }
+style.search_selection_text = { common.color "#dfdfdf" }
+
 style.syntax = {}
 style.syntax["normal"] = { common.color "#a0a0a0" }
 style.syntax["symbol"] = { common.color "#a0a0a0" }

--- a/colors/everblush.lua
+++ b/colors/everblush.lua
@@ -20,6 +20,9 @@ style.line_highlight = { common.color "#2d3437" }
 style.scrollbar = { common.color "#bab3e5" }
 style.scrollbar2 = { common.color "#c4bdef" }
 
+style.search_selection = { common.color "#33454d" }
+style.search_selection_text = { common.color "#7abaeb" }
+
 style.syntax["normal"] = { common.color "#b3b9b8" }
 style.syntax["symbol"] = { common.color "#b3b9b8" }
 style.syntax["comment"] = { common.color "#404749" }

--- a/colors/everforest.lua
+++ b/colors/everforest.lua
@@ -17,6 +17,9 @@ style.scrollbar = { common.color "#4F5B58"}
 style.scrollbar2 = { common.color "#4F5B58"}
 style.scrollbar_track = { common.color "#272E33"}
 
+style.search_selection = { common.color "#004d00" }
+style.search_selection_text = { common.color "#b9cd98" }
+
 style.syntax["normal"] = { common.color "#D3C6AA"}
 style.syntax["symbol"] = { common.color "#D3C6AA"}
 style.syntax["comment"] = {common.color "#4F5B58"}

--- a/colors/everforest_light.lua
+++ b/colors/everforest_light.lua
@@ -18,6 +18,9 @@ style.scrollbar2 = { common.color "#BEC5B2"}
 style.scrollbar_track = { common.color "#EDEADA"}
 style.drag_overlay = { common.color "#BEC5B233"}
 
+style.search_selection = { common.color "#ffe699" }
+style.search_selection_text = { common.color "#394247" }
+
 style.syntax["normal"] = { common.color "#5C6A72"}
 style.syntax["symbol"] = { common.color "#5C6A72"}
 style.syntax["comment"] = {common.color "#A6B0A0"}

--- a/colors/flexoki_dark.lua
+++ b/colors/flexoki_dark.lua
@@ -14,16 +14,19 @@ style.dim = { common.color "#CECDC3" }
 style.divider = { common.color "#403E3C" }  -- ui-3
 style.selection = { common.color "#343331" }  -- ui-2
 style.line_number = { common.color "#6F6E69" }
-style.line_number2 = { common.color "#100F0F" }  -- black
+style.line_number2 = { common.color "#353131" }  -- black
 style.line_highlight = { common.color "#575653" }  -- tx-3
 style.scrollbar = { common.color "#DAD8CE" }  -- tx-1
 style.scrollbar2 = { common.color "#878580" }  -- tx-2
 
+style.search_selection = { common.color "#5b575a" }
+style.search_selection_text = { common.color "#ffc21a" }
+
 style.syntax["normal"] = { common.color "#282726" }  -- ui
 style.syntax["symbol"] = { common.color "#5E409D" }  -- purple
 style.syntax["comment"] = { common.color "#6F6E69" }  -- tx-2
-style.syntax["keyword"] = { common.color "#AF3029" }  -- red
-style.syntax["keyword2"] = { common.color "#205EA6" }  -- blue
+style.syntax["keyword"] = { common.color "#d34c45" }  -- red
+style.syntax["keyword2"] = { common.color "#3e87da" }  -- blue
 style.syntax["number"] = { common.color "#66800B" }  -- green
 style.syntax["literal"] = { common.color "#AD8301" }  -- yellow
 style.syntax["string"] = { common.color "#BC5215" }  -- orange

--- a/colors/flexoki_light.lua
+++ b/colors/flexoki_light.lua
@@ -19,7 +19,10 @@ style.line_highlight = { common.color "#B7B5AC" }  -- tx-3
 style.scrollbar = { common.color "#E6E4D9" }  -- ui
 style.scrollbar2 = { common.color "#B7B5AC" }  -- tx-3
 
-style.syntax["normal"] = { common.color "#E6E4D9" }  -- ui
+style.search_selection = { common.color "#52527a" }
+style.search_selection_text = { common.color "#ffc21a" }
+
+style.syntax["normal"] = { common.color "#7c7650" }  -- ui
 style.syntax["symbol"] = { common.color "#8B7EC8" }  -- purple
 style.syntax["comment"] = { common.color "#6F6E69" }  -- tx-2
 style.syntax["keyword"] = { common.color "#D14D41" }  -- red

--- a/colors/focus.lua
+++ b/colors/focus.lua
@@ -20,13 +20,16 @@ style.scrollbar2 = { common.color "#33CCCC4C" }
 style.scrollbar_track = { common.color "#10191F4C" }
 style.guide = { common.color "#1F2F3A" } -- indentguide
 
+style.search_selection = { common.color "#6a5acd" }
+style.search_selection_text = { common.color "#ffffff" }
+
 style.syntax["normal"] = { common.color "#82AAA3" }
 style.syntax["symbol"] = { common.color "#BFC9DB" }
 style.syntax["comment"] = { common.color "#87919D" }
 style.syntax["keyword"] = { common.color "#E67D74" }
 style.syntax["keyword2"] = { common.color "#ffffff" }
 style.syntax["number"] = { common.color "#D699B5" }
-style.syntax["literal"] = { common.color "#ea5964" } 
+style.syntax["literal"] = { common.color "#ea5964" }
 style.syntax["string"] = { common.color "#D4BC7D" }
 style.syntax["operator"] = { common.color "#E0AD82" }
 style.syntax["function"] = { common.color "#D0C5A9" }

--- a/colors/focus.lua
+++ b/colors/focus.lua
@@ -23,13 +23,13 @@ style.guide = { common.color "#1F2F3A" } -- indentguide
 style.search_selection = { common.color "#6a5acd" }
 style.search_selection_text = { common.color "#ffffff" }
 
-style.syntax["normal"] = { common.color "#82AAA3" }
+style.syntax["normal"] = { common.color "#BFC9DB" }
 style.syntax["symbol"] = { common.color "#BFC9DB" }
 style.syntax["comment"] = { common.color "#87919D" }
 style.syntax["keyword"] = { common.color "#E67D74" }
-style.syntax["keyword2"] = { common.color "#ffffff" }
+style.syntax["keyword2"] = { common.color "#82AAA3" }
 style.syntax["number"] = { common.color "#D699B5" }
-style.syntax["literal"] = { common.color "#ea5964" }
+style.syntax["literal"] = { common.color "#82AAA3" }
 style.syntax["string"] = { common.color "#D4BC7D" }
 style.syntax["operator"] = { common.color "#E0AD82" }
 style.syntax["function"] = { common.color "#D0C5A9" }

--- a/colors/github-dark-dimmed.lua
+++ b/colors/github-dark-dimmed.lua
@@ -26,6 +26,9 @@ style.line_highlight = bg2
 style.scrol = fgdim
 style.scrollbar2 = fg
 
+style.search_selection = { common.color "#b3b3b3" }
+style.search_selection_text = { common.color "#384047" }
+
 style.syntax["normal"] = fg
 style.syntax["symbol"] = fg
 style.syntax["comment"] = fgdim

--- a/colors/github.lua
+++ b/colors/github.lua
@@ -19,6 +19,9 @@ style.line_highlight = { common.color "#f2f2f2" }
 style.scrollbar = { common.color "#e0e0e0" }
 style.scrollbar2 = { common.color "#c0c0c0" }
 
+style.search_selection = { common.color "#b3b3b3" }
+style.search_selection_text = { common.color "#384047" }
+
 style.syntax["normal"] = { common.color "#24292e" }
 style.syntax["symbol"] = { common.color "#24292e" }
 style.syntax["comment"] = { common.color "#6a737d" }

--- a/colors/github_dark.lua
+++ b/colors/github_dark.lua
@@ -26,6 +26,9 @@ style.line_highlight = {common.color "#1e202e"}
 style.scrollbar = fgdim
 style.scrollbar2 = fg
 
+style.search_selection = { common.color "#b3b3b3" }
+style.search_selection_text = { common.color "#384047" }
+
 style.syntax["normal"] = fg
 style.syntax["symbol"] = fg
 style.syntax["comment"] = fgdim

--- a/colors/gruvbox-material-dark-hard.lua
+++ b/colors/gruvbox-material-dark-hard.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#666666" }
+style.search_selection_text = { common.color "#ffa64d" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox-material-dark-medium.lua
+++ b/colors/gruvbox-material-dark-medium.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#666666" }
+style.search_selection_text = { common.color "#ffa64d" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox-material-dark-soft.lua
+++ b/colors/gruvbox-material-dark-soft.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#666666" }
+style.search_selection_text = { common.color "#ffa64d" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox-material-light-hard.lua
+++ b/colors/gruvbox-material-light-hard.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#f3d458" }
+style.search_selection_text = { common.color "#2f2704" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox-material-light-medium.lua
+++ b/colors/gruvbox-material-light-medium.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#f3d458" }
+style.search_selection_text = { common.color "#2f2704" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox-material-light-soft.lua
+++ b/colors/gruvbox-material-light-soft.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#f3d458" }
+style.search_selection_text = { common.color "#2f2704" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base04

--- a/colors/gruvbox_dark.lua
+++ b/colors/gruvbox_dark.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#32302f" }
 style.scrollbar = { common.color "#928374" }
 style.scrollbar2 = { common.color "#fbf1c7" }
 
+style.search_selection = { common.color "#595959" }
+style.search_selection_text = { common.color "#ffcccc" }
+
 style.syntax["normal"] = { common.color "#ebdbb2" }
 style.syntax["symbol"] = { common.color "#ebdbb2" }
 style.syntax["comment"] = { common.color "#928374" }

--- a/colors/gruvbox_light.lua
+++ b/colors/gruvbox_light.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#f2e5bc" }
 style.scrollbar = { common.color "#928374" }
 style.scrollbar2 = { common.color "#282828" }
 
+style.search_selection = { common.color "#f3d459" }
+style.search_selection_text = { common.color "#3c3836" }
+
 style.syntax["normal"] = { common.color "#3c3836" }
 style.syntax["symbol"] = { common.color "#3c3836" }
 style.syntax["comment"] = { common.color "#928374" }

--- a/colors/hackersden.lua
+++ b/colors/hackersden.lua
@@ -27,6 +27,9 @@ style.warn = { common.color "#966a3b" }
 style.error = { common.color "#ff3333" }
 style.modified = { common.color "#1c7c9c" }
 
+style.search_selection = { common.color "#4d4d4d" }
+style.search_selection_text = { common.color "#42f076" }
+
 style.syntax["normal"] = { common.color "#ffffff" }
 style.syntax["symbol"] = { common.color "#ff4f90" }
 style.syntax["comment"] = { common.color "#8b949e" }

--- a/colors/handmade_hero.lua
+++ b/colors/handmade_hero.lua
@@ -26,6 +26,6 @@ style.syntax["keyword"] = { common.color "#d99f0d" }
 style.syntax["keyword2"] = { common.color "#d99f0d" }
 style.syntax["number"] = { common.color "#d699b5" }
 style.syntax["literal"] = { common.color "#e67d74" }
-style.syntax["string"] = { common.color "#cdaa7d" }
+style.syntax["string"] = { common.color "#7aa329" }
 style.syntax["operator"] = { common.color "#cdaa7d" }
 style.syntax["function"] = { common.color "#c69f6c" }

--- a/colors/handmade_hero.lua
+++ b/colors/handmade_hero.lua
@@ -1,0 +1,31 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#161616" }
+style.background2 = { common.color "#141414" }
+style.background3 = { common.color "#1e1e1e" }
+style.text = { common.color "#dbc3a3" }
+style.caret = { common.color "#ffcc66" }
+style.accent = { common.color "#eadbc8" }
+style.dim = { common.color "#6a6a6a" }
+style.divider = { common.color "#3a3a3a" }
+style.selection = { common.color "#444444" }
+style.line_highlight = { common.color "#333333" }
+style.line_number = { common.color "#484848" }
+style.line_number2 = { common.color "#484848" }
+style.scrollbar = { common.color "#3A3A3A" }
+style.scrollbar2 = { common.color "#555555" }
+
+style.search_selection = { common.color "#6a5acd" }
+style.search_selection_text = { common.color "#ffffff" }
+
+style.syntax["normal"] = { common.color "#d4b791" }
+style.syntax["symbol"] = { common.color "#d3b792" }
+style.syntax["comment"] = { common.color "#6A6A6A" }
+style.syntax["keyword"] = { common.color "#d99f0d" }
+style.syntax["keyword2"] = { common.color "#d99f0d" }
+style.syntax["number"] = { common.color "#d699b5" }
+style.syntax["literal"] = { common.color "#e67d74" }
+style.syntax["string"] = { common.color "#cdaa7d" }
+style.syntax["operator"] = { common.color "#cdaa7d" }
+style.syntax["function"] = { common.color "#c69f6c" }

--- a/colors/jb-fleet.lua
+++ b/colors/jb-fleet.lua
@@ -19,6 +19,9 @@ style.line_highlight = { common.color "#292929" }
 style.scrollbar = { common.color "#3a3a3a" }
 style.scrollbar2 = { common.color "#313131" }
 
+style.search_selection = { common.color "#4d4d4d" }
+style.search_selection_text = { common.color "#42f076" }
+
 style.syntax["normal"] = { common.color "#e6e6e6" }
 style.syntax["symbol"] = { common.color "#e6e6e6" }
 style.syntax["comment"] = { common.color "#6d6d6d" }
@@ -39,10 +42,10 @@ local darkergray = { common.color "#bbbbbb" }
 local whoablue = { common.color "#87c3ff" }
 local syncols = {
   ["keyword.return"] = style.syntax["keyword"],
-  
+
   ["type"] = style.syntax["keyword2"],
   ["type.builtin"] = style.syntax["keyword"],
-  
+
   ["boolean"] = whoablue,
   ["parameter"] = darkergray,
   ["field"] = whoablue,

--- a/colors/jellybeans.lua
+++ b/colors/jellybeans.lua
@@ -18,6 +18,9 @@ style.line_highlight = { common.color "#191919"}
 style.scrollbar = { common.color "#2e2e2e" }
 style.scrollbar2 = { common.color "#3b3b3b" } -- Hovered
 
+style.search_selection = { common.color "#4d4d4d" }
+style.search_selection_text = { common.color "#e6e600" }
+
 style.syntax["normal"] = { common.color "#6b8b9b" }
 style.syntax["symbol"] = { common.color "#e8e8d3" }
 style.syntax["comment"] = { common.color "#888888" }

--- a/colors/liqube.lua
+++ b/colors/liqube.lua
@@ -19,6 +19,9 @@ style.scrollbar = { common.color "#3d3f43" }
 style.scrollbar2 = { common.color "#595b5f" }
 style.guide = { common.color "#1c1f25" } -- indentguide
 
+style.search_selection = { common.color "#4d4d4d" }
+style.search_selection_text = { common.color "#e6e600" }
+
 style.syntax["normal"] = { common.color "#abb2bf" }
 style.syntax["symbol"] = { common.color "#71a9d7" }
 style.syntax["comment"] = { common.color "#5c6370" }

--- a/colors/mariana.lua
+++ b/colors/mariana.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#303841" }
 style.scrollbar = { common.color "#696f75" }
 style.scrollbar2 = { common.color "#444b53" }
 
+style.search_selection = { common.color "#627084" }
+style.search_selection_text = { common.color "#ffcc66" }
+
 style.syntax["normal"] = { common.color "#d7dde9" }
 style.syntax["symbol"] = { common.color "#d8dee9" }
 style.syntax["comment"] = { common.color "#a6acb9" }

--- a/colors/mobilephone.lua
+++ b/colors/mobilephone.lua
@@ -27,6 +27,9 @@ style.warn = { common.color "#f5e728" }
 style.error = { common.color "#ff3333" }
 style.modified = { common.color "#e0d316" }
 
+style.search_selection = { common.color "#627084" }
+style.search_selection_text = { common.color "#66ff33" }
+
 style.syntax["normal"] = { common.color "#ffffff" }
 style.syntax["symbol"] = { common.color "#ff4f90" }
 style.syntax["comment"] = { common.color "#8b949e" }

--- a/colors/moe.lua
+++ b/colors/moe.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#f2f2f2" }
 style.scrollbar = { common.color "#e0e0e0" }
 style.scrollbar2 = { common.color "#c0c0c0" }
 
+style.search_selection = { common.color "#6e9191" }
+style.search_selection_text = { common.color "#f0f4f4" }
+
 style.syntax["normal"] = { common.color "#181818" }
 style.syntax["symbol"] = { common.color "#181818" }
 style.syntax["comment"] = { common.color "#43cdbd" }

--- a/colors/monodark.lua
+++ b/colors/monodark.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#101010" }
 style.scrollbar = { common.color "#252525" }
 style.scrollbar2 = { common.color "#303030" }
 
+style.search_selection = { common.color "#6e9191" }
+style.search_selection_text = { common.color "#f0f4f4" }
+
 style.syntax = {}
 style.syntax["normal"] = { common.color "#a0a0a0" }
 style.syntax["symbol"] = { common.color "#a0a0a0" }

--- a/colors/monokai-pro-classic.lua
+++ b/colors/monokai-pro-classic.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#36372f" }
 style.scrollbar = { common.color "#49483E" }
 style.scrollbar2 = { common.color "#636254" }
 
+style.search_selection = { common.color "#6c6e5e" }
+style.search_selection_text = { common.color "#ffccff" }
+
 style.syntax["normal"] = { common.color "#F8F8F2" }
 style.syntax["symbol"] = { common.color "#F8F8F2" }
 style.syntax["comment"] = { common.color "#75715E" }

--- a/colors/monokai-sublime.lua
+++ b/colors/monokai-sublime.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#282923" }
 style.scrollbar = { common.color "#53534F" }
 style.scrollbar2 = { common.color "#53534F" }
 
+style.search_selection = { common.color "#6c6e5e" }
+style.search_selection_text = { common.color "#ffccff" }
+
 style.syntax["normal"] = { common.color "#F8F8F2" }
 style.syntax["symbol"] = { common.color "#F8F8F2" }
 style.syntax["comment"] = { common.color "#74705D" }

--- a/colors/monokai.lua
+++ b/colors/monokai.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#49483E" }
 style.scrollbar = { common.color "#53534F" }
 style.scrollbar2 = { common.color "#53534F" }
 
+style.search_selection = { common.color "#6c6e5e" }
+style.search_selection_text = { common.color "#ffb3ff" }
+
 style.syntax["normal"] = { common.color "#F8F8F2" }
 style.syntax["symbol"] = { common.color "#F8F8F2" }
 style.syntax["comment"] = { common.color "#75715E" }

--- a/colors/nebula.lua
+++ b/colors/nebula.lua
@@ -46,6 +46,9 @@ style.warn             = base09
 style.error            = base08
 style.modified         = base12
 
+style.search_selection = { common.color "#6c6e5e" }
+style.search_selection_text = { common.color "#ffd633" }
+
 style.syntax["normal"]   = base05
 style.syntax["symbol"]   = base05
 style.syntax["comment"]  = base03

--- a/colors/nord.lua
+++ b/colors/nord.lua
@@ -32,6 +32,9 @@ style.syntax["string"] = { common.color "#A3BE8C" }
 style.syntax["operator"] = { common.color "#81A1C1" }
 style.syntax["function"] = { common.color "#88C0D0" }
 
+style.search_selection = { common.color "#566176" }
+style.search_selection_text = { common.color "#80e5ff" }
+
 config.highlight_current_line = "no_selection"
 
 style.guide = { common.color "#434c5eb3" }

--- a/colors/onedark.lua
+++ b/colors/onedark.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#2C333E" }
 style.scrollbar = { common.color "#4f5873" }
 style.scrollbar2 = { common.color "#3060C1" }
 
+style.search_selection = { common.color "#566176" }
+style.search_selection_text = { common.color "#80e5ff" }
+
 style.syntax["normal"] = { common.color "#abb2bf" }
 style.syntax["symbol"] = { common.color "#abb2bf" }
 style.syntax["comment"] = { common.color "#5f697a" }

--- a/colors/only_dark.lua
+++ b/colors/only_dark.lua
@@ -19,6 +19,9 @@ style.line_highlight = { common.color "#343438" }
 style.scrollbar = { common.color "#414146" }
 style.scrollbar2 = { common.color "#4b4bff" }
 
+style.search_selection = { common.color "#566176" }
+style.search_selection_text = { common.color "#80e5ff" }
+
 style.syntax["normal"] = { common.color "#e1e1e6" }
 style.syntax["symbol"] = { common.color "#97e1f1" }
 style.syntax["comment"] = { common.color "#676b6f" }

--- a/colors/oxocarbon-dark.lua
+++ b/colors/oxocarbon-dark.lua
@@ -44,6 +44,9 @@ style.selection = base02 -- editor selection
 style.guide = base02 -- indentation guide
 style.guide_highlighting = base02 -- indentation guide
 
+style.search_selection = { common.color "#737373" }
+style.search_selection_text = { common.color "#ffff33" }
+
 -- User Interface
 style.background2 = base00 -- sidebar
 style.background3 = base00 -- status bar

--- a/colors/oxocarbon-light.lua
+++ b/colors/oxocarbon-light.lua
@@ -44,6 +44,9 @@ style.selection = base02 -- editor selection
 style.guide = base02 -- indentation guide
 style.guide_highlighting = base02 -- indentation guide
 
+style.search_selection = { common.color "#d279a6" }
+style.search_selection_text = { common.color "#ffff00" }
+
 -- User Interface
 style.background2 = base00 -- sidebar
 style.background3 = base00 -- status bar

--- a/colors/plasma.lua
+++ b/colors/plasma.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#2b2b2f"}
 style.scrollbar = { common.color "#313136" }
 style.scrollbar2 = { common.color "#bfbfbf" }
 
+style.search_selection = { common.color "#bf4080" }
+style.search_selection_text = { common.color "#ffff00" }
+
 style.syntax["normal"] = { common.color "#dddddd" }
 style.syntax["symbol"] = { common.color "#e06c75" }
 style.syntax["comment"] = { common.color "#c5c5c5" }

--- a/colors/predawn.lua
+++ b/colors/predawn.lua
@@ -17,6 +17,9 @@ style.line_highlight = { common.color "#3C3C3C" }
 style.scrollbar = { common.color "#4C4C4C" }
 style.scrollbar2 = { common.color "#777777" }
 
+style.search_selection = { common.color "#666666" }
+style.search_selection_text = { common.color "#ffff00" }
+
 style.syntax["normal"] = { common.color "#F18260" }
 style.syntax["symbol"] = { common.color "#F1F1F1" }
 style.syntax["comment"] = { common.color "#777777" }

--- a/colors/rose-pine-dawn.lua
+++ b/colors/rose-pine-dawn.lua
@@ -46,6 +46,9 @@ style.warn = { common.color(rose_pine_dawn.gold) }
 style.error = { common.color(rose_pine_dawn.love) }
 style.modified = { common.color(rose_pine_dawn.foam) }
 
+style.search_selection = { common.color "#d39d5f" }
+style.search_selection_text = { common.color "#333333" }
+
 style.syntax["normal"] = { common.color(rose_pine_dawn.text) }
 style.syntax["symbol"] = { common.color(rose_pine_dawn.text) }
 style.syntax["comment"] = { common.color(rose_pine_dawn.muted) }

--- a/colors/rose-pine-moon.lua
+++ b/colors/rose-pine-moon.lua
@@ -4,7 +4,7 @@ local common = require("core.common")
 local rose_pine_moon = {}
 
 rose_pine_moon.base = "#232136"
-rose_pine_moon.surface = "#2a273f"
+rose_pine_moon.surface = "#3f3c5d"
 rose_pine_moon.overlay = "#393552"
 rose_pine_moon.muted = "#6e6a86"
 rose_pine_moon.subtle = "#908caa"
@@ -45,6 +45,9 @@ style.good = { common.color(rose_pine_moon.iris) }
 style.warn = { common.color(rose_pine_moon.gold) }
 style.error = { common.color(rose_pine_moon.love) }
 style.modified = { common.color(rose_pine_moon.foam) }
+
+style.search_selection = { common.color "#d39d5f" }
+style.search_selection_text = { common.color "#333333" }
 
 style.syntax["normal"] = { common.color(rose_pine_moon.text) }
 style.syntax["symbol"] = { common.color(rose_pine_moon.text) }

--- a/colors/rose-pine.lua
+++ b/colors/rose-pine.lua
@@ -46,6 +46,9 @@ style.warn = { common.color(rose_pine.gold) }
 style.error = { common.color(rose_pine.love) }
 style.modified = { common.color(rose_pine.foam) }
 
+style.search_selection = { common.color "#666666" }
+style.search_selection_text = { common.color "#ffff00" }
+
 style.syntax["normal"] = { common.color(rose_pine.text) }
 style.syntax["symbol"] = { common.color(rose_pine.text) }
 style.syntax["comment"] = { common.color(rose_pine.muted) }

--- a/colors/solarized_dark.lua
+++ b/colors/solarized_dark.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#073642" }
 style.scrollbar = { common.color "#304A50" }
 style.scrollbar2 = { common.color "#465356" }
 
+style.search_selection = { common.color "#00ccff" }
+style.search_selection_text = { common.color "#333333" }
+
 style.syntax["normal"] = { common.color "#93A1A1" }
 style.syntax["symbol"] = { common.color "#93A1A1" }
 style.syntax["comment"] = { common.color "#586e75" }

--- a/colors/solarized_light.lua
+++ b/colors/solarized_light.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#eee8d5" }
 style.scrollbar = { common.color "#e0dbc8" }
 style.scrollbar2 = { common.color "#bfbbaa" }
 
+style.search_selection = { common.color "#f0bb28" }
+style.search_selection_text = { common.color "#333333" }
+
 style.syntax["normal"] = { common.color "#657b83" }
 style.syntax["symbol"] = { common.color "#657b83" }
 style.syntax["comment"] = { common.color "#93a1a1" }

--- a/colors/solarobj.lua
+++ b/colors/solarobj.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#fcefcd" }
 style.scrollbar = { common.color "#e0dbc8" }
 style.scrollbar2 = { common.color "#9d9988" }
 
+style.search_selection = { common.color "#f0bb28" }
+style.search_selection_text = { common.color "#333333" }
+
 style.syntax["normal"] = { common.color "#3e3c37" }
 style.syntax["symbol"] = { common.color "#4c4f82" }
 style.syntax["comment"] = { common.color "#93a1a1" }

--- a/colors/synthwave.lua
+++ b/colors/synthwave.lua
@@ -22,6 +22,9 @@ style.nagbar_dim         = { common.color "rgba(0, 0, 0, 0.30)" }
 style.drag_overlay       = { common.color "rgba(0, 0, 0, 0.30)" }
 style.drag_overlay_tab   = { common.color "#f17e6e" }
 
+style.search_selection = { common.color "#007acc" }
+style.search_selection_text = { common.color "#ccebff" }
+
 style.syntax["normal"]   = { common.color "#FFFFFF" }
 style.syntax["symbol"]   = { common.color "#ff79c6" }
 style.syntax["comment"]  = { common.color "#9484bd" }

--- a/colors/tokyo-night.lua
+++ b/colors/tokyo-night.lua
@@ -28,6 +28,9 @@ style.warn = { common.color "#e0af68" }
 style.error = { common.color "#f7768e" }
 style.modified = { common.color "#7aa2f7" }
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#f0f0f5" }
+
 style.syntax["normal"] = { common.color "#9ABDF5" }
 style.syntax["symbol"] = { common.color "#c0caf5" }
 style.syntax["comment"] = { common.color "#414868" }

--- a/colors/vscode-dark.lua
+++ b/colors/vscode-dark.lua
@@ -19,6 +19,9 @@ style.line_highlight = { common.color "#333A40"}
 style.scrollbar = { common.color "#404040" }
 style.scrollbar2 = { common.color "#707070" } -- Hovered
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#f0f0f5" }
+
 style.syntax["normal"] = { common.color "#D4D4D4" }
 style.syntax["symbol"] = { common.color "#D4D4D4" }
 style.syntax["comment"] = { common.color "#6A9955" }

--- a/colors/winter.lua
+++ b/colors/winter.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#2d303d" }
 style.scrollbar = { common.color "#44475a" }
 style.scrollbar2 = { common.color "#4c5163" }
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#f0f0f5" }
+
 style.syntax["normal"] = { common.color "#f5faff" }
 style.syntax["symbol"] = { common.color "#f5faff" }
 style.syntax["comment"] = { common.color "#6272a4" }

--- a/colors/yaru.lua
+++ b/colors/yaru.lua
@@ -111,6 +111,9 @@ style.warn = colors.yellow_5
 style.error = colors.red_4
 style.modified = colors.blue_4
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#f0f0f5" }
+
 style.syntax["normal"] = colors.dark_2
 style.syntax["symbol"] = colors.dark_3
 style.syntax["comment"] = colors.purple_1

--- a/colors/yaru_dark.lua
+++ b/colors/yaru_dark.lua
@@ -116,6 +116,9 @@ style.warn = colors.yellow_4
 style.error = colors.red_4
 style.modified = colors.blue_3
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#f0f0f5" }
+
 style.syntax["normal"] = colors.light_5
 style.syntax["symbol"] = colors.light_6
 style.syntax["comment"] = colors.dark_1

--- a/colors/zenburn.lua
+++ b/colors/zenburn.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#383838" }
 style.scrollbar = { common.color "#4c4c4c" }
 style.scrollbar2 = { common.color "#5e5e5e" }
 
+style.search_selection = { common.color "#676b98" }
+style.search_selection_text = { common.color "#ffeee6" }
+
 style.syntax["normal"] = { common.color "#dcdccc" }
 style.syntax["symbol"] = { common.color "#dcdccc" }
 style.syntax["comment"] = { common.color "#7f9f7f" }

--- a/manifest.json
+++ b/manifest.json
@@ -9,12 +9,12 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id": "ayu-dark",
          "remote": "https://github.com/juliardi/lite-xl-ayu-theme.git:33a514527d4870480554771c273e667eb6418873",
-	 "version": "0.1",
+	 "version": "0.2",
          "type": "color",
          "tags": [
             "dark"
@@ -23,7 +23,7 @@
       {
          "id": "ayu-light",
          "remote": "https://github.com/juliardi/lite-xl-ayu-theme.git:33a514527d4870480554771c273e667eb6418873",
-	 "version": "0.1",
+	 "version": "0.2",
          "type": "color",
          "tags": [
             "light"
@@ -33,7 +33,7 @@
          "id": "ayu-mirage",
          "remote": "https://github.com/juliardi/lite-xl-ayu-theme.git:33a514527d4870480554771c273e667eb6418873",
          "type": "color",
-         "version": "0.1",
+         "version": "0.2",
          "tags": [
             "dark"
          ]
@@ -47,7 +47,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "betelgeuse",
@@ -58,7 +58,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "c0mfy",
@@ -69,7 +69,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "catppuccin-frappe",
@@ -80,7 +80,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "catppuccin-latte",
@@ -91,7 +91,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "catppuccin-macchiato",
@@ -102,7 +102,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "catppuccin-mocha",
@@ -113,7 +113,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "cold_lime",
@@ -124,7 +124,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "dracula",
@@ -135,7 +135,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "duorand",
@@ -146,7 +146,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "duotone",
@@ -157,7 +157,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "everblush",
@@ -168,7 +168,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "everforest",
@@ -190,7 +190,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "flexoki_dark",
@@ -201,7 +201,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "flexoki_light",
@@ -212,7 +212,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "focus",
@@ -223,7 +223,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "github",
@@ -234,7 +234,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "github-dark-dimmed",
@@ -245,7 +245,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "github_dark",
@@ -256,7 +256,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-dark-hard",
@@ -267,7 +267,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-dark-medium",
@@ -278,7 +278,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-dark-soft",
@@ -289,7 +289,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-light-hard",
@@ -300,7 +300,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-light-medium",
@@ -311,7 +311,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox-material-light-soft",
@@ -322,7 +322,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox_dark",
@@ -333,7 +333,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "gruvbox_light",
@@ -344,7 +344,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "hackersden",
@@ -355,7 +355,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "handmade_hero",
@@ -366,7 +366,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "jb-fleet",
@@ -377,7 +377,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "jellybeans",
@@ -388,7 +388,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "justperfect",
@@ -399,7 +399,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "liqube",
@@ -410,7 +410,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "mariana",
@@ -421,7 +421,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "mobilephone",
@@ -432,7 +432,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "moe",
@@ -443,7 +443,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "monodark",
@@ -454,7 +454,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "monokai",
@@ -465,7 +465,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "monokai-sublime",
@@ -476,7 +476,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "monokai-pro-classic",
@@ -487,7 +487,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "nebula",
@@ -498,7 +498,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "nord",
@@ -509,7 +509,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "onedark",
@@ -520,7 +520,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "only_dark",
@@ -531,7 +531,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "oxocarbon-dark",
@@ -553,7 +553,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "plasma",
@@ -564,7 +564,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "predawn",
@@ -575,7 +575,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "rose-pine",
@@ -586,7 +586,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "rose-pine-dawn",
@@ -597,7 +597,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "rose-pine-moon",
@@ -608,7 +608,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "solarized_dark",
@@ -619,7 +619,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "solarized_light",
@@ -630,7 +630,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "solarobj",
@@ -641,7 +641,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "synthwave",
@@ -663,7 +663,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "vscode-dark",
@@ -674,7 +674,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "winter",
@@ -685,7 +685,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "yaru",
@@ -696,7 +696,7 @@
             "light"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "yaru_dark",
@@ -707,7 +707,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       },
       {
          "id" : "zenburn",
@@ -718,7 +718,7 @@
             "dark"
          ],
          "type" : "color",
-         "version" : "0.1"
+         "version" : "0.2"
       }
    ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -358,6 +358,17 @@
          "version" : "0.1"
       },
       {
+         "id" : "handmade_hero",
+         "mod_version" : "3.0.0",
+         "name" : "handmade_hero",
+         "path" : "colors/handmade_hero.lua",
+         "tags" : [
+            "dark"
+         ],
+         "type" : "color",
+         "version" : "0.1"
+      },
+      {
          "id" : "jb-fleet",
          "mod_version" : "3.0.0",
          "name" : "jb-fleet",


### PR DESCRIPTION
Added `style.search_selection` and `style.search_selection_text` colors for the color themes so the colors don't clash with the background and caret colors. This also adds a `handmade_hero` color theme based on Casey Muratori's Handmade Hero series.

Some of these color themes need some love in general, but there are too many of them to fix them all right now.
We should keep accessibility in mind, the new feature from https://github.com/pragtical/pragtical/pull/312 helps a lot when you've been looking at code for the nineth hour.

At some point, it would be wise to do another run through all color themes and compare them against something like https://webaim.org/resources/contrastchecker/ to check for proper contrast. Accessibility is important, we spend all day in front of monitors.